### PR TITLE
Fixes bug which mutates line(histogram) data 

### DIFF
--- a/src/feature-viewer.js
+++ b/src/feature-viewer.js
@@ -586,14 +586,14 @@ var FeatureViewer = (function () {
                     level = maxValue > level ? maxValue : level;
                     
 
-                    object.data[i] = [object.data[i].map(function (d) {
+                    object.data[i] = object.data[i].map(function (d) {
                         return {
                             x: d.x,
                             y: d.y,
                             id: d.id,
                             description: d.description
                         }
-                    })]
+                    });
                 }
                 lineYscale.range([0, -(shift)]).domain([0, -(level)]);
                 pathLevel = shift * 10 +5;
@@ -911,7 +911,7 @@ var FeatureViewer = (function () {
                     .style("stroke-width", "1px");
                 object.data.forEach(function(dd,i,array){
                     histog.selectAll("." + object.className + i)
-                    .data(dd)
+                    .data([dd])
                     .enter()
                     .append("path")
                     .attr("clip-path", "url(#clip)")


### PR DESCRIPTION
Minor bugfix: If you pass an object for a line-type feature, the data attribute ends up being converted in to a triply-nested array. Passing in the same feature-spec again won't draw that feature (because the data[0][0] is an array, rather than the first {x:1, y:0.5} pair). This PR changes the point at which the extra layer of array is added (i.e. it doesn't change the input data in to a form that won't render). 